### PR TITLE
Use regex to replace all instances of %TITLE%

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -35,7 +35,7 @@ const processFile = (file, currentPath) => {
       fs.appendFileSync(newFilePath, newFile)
     } else {
       // if it's not a binary file, treat it as a template
-      const templateFile = newFile.toString().replace('%TITLE%', appTitle)
+      const templateFile = newFile.toString().replace(/%TITLE%/g, appTitle)
       fs.appendFileSync(newFilePath, templateFile)
     }
   }


### PR DESCRIPTION
Closes #7.

Didn't write a formal test but the following snippet shows the regex replacement should work:

```javascript
var string = 'This has %TITLE% in it once - no, it has %TITLE% twice';
var rep = 'SOME_TITLE_YO';

console.log('Start string: ' + string); // 'This has %TITLE% in it once - no, it has %TITLE% twice'

string = string.replace(/%TITLE%/g, rep);

console.log('Replaced string: ' + string); // 'This has SOME_TITLE_YO in it once - no, it has SOME_TITLE_YO twice'
```