### PR TITLE
use webpack in favor of budo and browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one-express",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "description": "Generator to build Tram-One applications quickly",
   "bin": "./generator.js",
   "files": [

--- a/template/package.json
+++ b/template/package.json
@@ -2,20 +2,19 @@
   "name": "%TITLE%",
   "version": "1.0.0",
   "scripts": {
-    "start": "budo main.js:bundle.js --pushstate --dir public --live",
-    "prebuild": "cp -r public/ dist",
-    "build": "browserify ./main.js -o ./dist/bundle.js -t [ babelify --presets [ env ] ]",
+    "start": "webpack-serve --content ./public",
+    "prebuild": "cp -r ./public/ dist",
+    "build": "webpack",
     "test": "jasmine ./specs/specs.js"
   },
   "keywords": [
     "tram-one"
   ],
   "dependencies": {
-    "babel-preset-env": "^1.6.0",
-    "babelify": "^7.3.0",
-    "browserify": "^14.4.0",
-    "budo": "^10.0.4",
     "jasmine": "^2.8.0",
-    "tram-one": "^5.2.1"
+    "tram-one": "^6.1.0",
+    "webpack": "^4.8.3",
+    "webpack-command": "^0.2.0",
+    "webpack-serve": "^1.0.2"
   }
 }

--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -1,0 +1,13 @@
+const path = require('path')
+
+module.exports = {
+  entry: './main.js',
+  externals: {
+    domino: 'domino'
+  },
+  output: {
+    filename: 'bundle.js',
+    publicPath: './public',
+    path: path.resolve(__dirname, 'dist')
+  }
+}


### PR DESCRIPTION
## Summary

In an effort to have more succinct dependencies, using `webpack` to build and serve the project.  

fixes #26 