### PR TITLE
use tram-dev-server-config for dev-server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one-express",
-  "version": "8.0.1",
+  "version": "9.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one-express",
-  "version": "8.0.1",
+  "version": "9.0.0",
   "description": "Generator to build Tram-One applications quickly",
   "bin": "./generator.js",
   "files": [

--- a/template/package.json
+++ b/template/package.json
@@ -2,7 +2,7 @@
   "name": "%TITLE%",
   "version": "1.0.0",
   "scripts": {
-    "start": "webpack-serve --content ./public",
+    "start": "webpack-serve",
     "prebuild": "cp -r ./public/ dist",
     "build": "webpack",
     "test": "jasmine ./specs/specs.js"
@@ -13,6 +13,7 @@
   "dependencies": {
     "jasmine": "^2.8.0",
     "tram-one": "^6.1.0",
+    "tram-dev-server-config": "^1.0.0",
     "webpack": "^4.8.3",
     "webpack-command": "^0.2.0",
     "webpack-serve": "^1.0.2"

--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -11,3 +11,5 @@ module.exports = {
     path: path.resolve(__dirname, 'dist')
   }
 }
+
+module.exports.serve = require('tram-dev-server-config')


### PR DESCRIPTION
## Summary
Routes were not redirecting to tram-one routes on index.html for the dev server. Including a tram-one configuration (with it's own dependencies) should resolve the issue.