### PR TITLE
make serve property condition (workaround until git issue is published)

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "jasmine": "^2.8.0",
     "tram-one": "^6.1.0",
-    "tram-dev-server-config": "^1.0.0",
+    "tram-dev-server-config": "^1.0.1",
     "webpack": "^4.8.3",
     "webpack-command": "^0.2.0",
     "webpack-serve": "^1.0.2"

--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -12,4 +12,6 @@ module.exports = {
   }
 }
 
-module.exports.serve = require('tram-dev-server-config')
+if (process.argv[1].split('/').includes('webpack-serve')) {
+  module.exports.serve = require('tram-dev-server-config')
+}


### PR DESCRIPTION
## Summary

As of right now, webpack throws an error on build because it treats `serve` as an invalid property. This should be resolved in a merged PR (but has yet to be published).

This conditional logic should allow both the build and start script to work as normal