### PR TITLE
add support for windows in webpack config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one-express",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one-express",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "description": "Generator to build Tram-One applications quickly",
   "bin": "./generator.js",
   "files": [

--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -12,6 +12,6 @@ module.exports = {
   }
 }
 
-if (process.argv[1].split('/').includes('webpack-serve')) {
+if (process.argv[1].split(path.sep).includes('webpack-serve')) {
   module.exports.serve = require('tram-dev-server-config')
 }


### PR DESCRIPTION
## Summary

Ran into an issue where the webpack server was not loading the tram-one config because the path separator was for Unix only. Using `path.sep` and have verified on Windows machine manually that this works...