### PR TITLE
configure webpack to produce source maps when in running webpack serve

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,5 +48,5 @@ Below are a list of commands used for developement. The logic for all the comman
 - `npm run example-build` - runs `npm run build` in the example project
 - `npm run example-start` - runs the start script, which kicks off a webpack server
 - `npm run example-start-and-kill` - runs the webpack server, and then runs jasmine tests against the server (verifying that the default pages load correctly)
-- `npm run example-check` - the tests run against the example server in `example-start-and-kill`, can also be run independently after starting the example app
+- `npm run example-check` - verifies default pages load correctly for a running instance of the example app (used in example-start-and-kill)
 - `npm run example-test` - runs the test suite for the example app

--- a/README.md
+++ b/README.md
@@ -43,4 +43,10 @@ app-name/
 
 ## Developement Commands
 Below are a list of commands used for developement. The logic for all the commands are in the local `package.json`
-- `npm start` - creates an example app `tram-one-example`
+- `npm run generate-example` - alias for `example-generate`
+- `npm run example-generate` - creates an example app and installs dependencies in the example
+- `npm run example-build` - runs `npm run build` in the example project
+- `npm run example-start` - runs the start script, which kicks off a webpack server
+- `npm run example-start-and-kill` - runs the webpack server, and then runs jasmine tests against the server (verifying that the default pages load correctly)
+- `npm run example-check` - the tests run against the example server in `example-start-and-kill`, can also be run independently after starting the example app
+- `npm run example-test` - runs the test suite for the example app

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one-express",
-  "version": "9.0.2",
+  "version": "9.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one-express",
-  "version": "9.0.2",
+  "version": "9.1.0",
   "description": "Generator to build Tram-One applications quickly",
   "bin": "./generator.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   ],
   "scripts": {
     "lint": "xo generator.js",
-    "example-generate": "node generator.js tram-one-example",
+    "generate-example": "npm run example-generate",
+    "example-generate": "rm -rf tram-one-example && node generator.js tram-one-example",
     "postexample-generate": "npm --prefix ./tram-one-example install",
     "example-build": "npm --prefix ./tram-one-example run build",
     "example-start": "npm --prefix ./tram-one-example start",

--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -2,6 +2,7 @@ const path = require('path')
 
 module.exports = {
   entry: './main.js',
+  mode: process.env.WEBPACK_SERVE ? 'development' : 'production',
   externals: {
     domino: 'domino'
   },
@@ -12,6 +13,6 @@ module.exports = {
   }
 }
 
-if (process.argv[1].split(path.sep).includes('webpack-serve')) {
+if (process.env.WEBPACK_SERVE) {
   module.exports.serve = require('tram-dev-server-config')
 }


### PR DESCRIPTION
## Summary

Before we were not offering source-maps when running `npm start` for development. The recommended setup comes from the webpack-serve repo: https://github.com/webpack-contrib/webpack-serve#setting-the-config-mode

Also included in this PR are README changes to detail all the commands (all of which we run in CircleCI)