### PR TITLE
Should not run Babel Transforms when running development

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one-express",
-  "version": "12.0.0",
+  "version": "12.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one-express",
-  "version": "12.0.0",
+  "version": "12.1.0",
   "description": "Generator to build Tram-One applications quickly",
   "bin": "./generator.js",
   "files": [

--- a/template/webpack-module.config.js
+++ b/template/webpack-module.config.js
@@ -1,5 +1,7 @@
 // module config for webpack
-module.exports = (nodeEnv) => ({
+module.exports = (nodeEnv) => nodeEnv === 'development' ?
+{} :
+({
   rules: [
     {
       use: {


### PR DESCRIPTION
## Summary

During development it can be difficult to debug source code if babel has injected it's plugins and transformed all the syntax (most obviously the template literals).

This PR makes it so that during development, no transforms are applied (this can be changed by simply reverting what's here)