### PR TITLE
use webpack env

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one-express",
-  "version": "13.0.0",
+  "version": "13.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one-express",
-  "version": "13.0.0",
+  "version": "13.1.0",
   "description": "Generator to build Tram-One applications quickly",
   "bin": "./generator.js",
   "files": [

--- a/template/package.json
+++ b/template/package.json
@@ -2,9 +2,9 @@
   "name": "%TITLE%",
   "version": "1.0.0",
   "scripts": {
-    "start": "NODE_ENV=development webpack-dev-server --open --hot --inline=true",
+    "start": "webpack-dev-server --env development --open --hot --inline=true",
     "prebuild": "cp -r ./public/ dist",
-    "build": "NODE_ENV=production webpack",
+    "build": "webpack --env production",
     "test": "jasmine ./specs/specs.js",
     "postbuild": "tram-build-page -a './main.js' -r '/no-js' -i './public/index.html' -o './dist/index.html'"
   },

--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -8,7 +8,7 @@ const dehydratedIndex = buildPage({
   indexPath: './public/index.html'
 })
 
-module.exports = {
+module.exports = env => ({
   entry: './main.js',
   devServer: {
     before: app => {
@@ -29,8 +29,8 @@ module.exports = {
     inline: true,
     host: '0.0.0.0'
   },
-  mode: process.env.NODE_ENV,
-  module: moduleConfig(process.env.NODE_ENV),
+  mode: env,
+  module: moduleConfig(env),
   externals: {
     domino: 'domino'
   },
@@ -38,4 +38,4 @@ module.exports = {
     filename: 'bundle.js',
     path: path.resolve(__dirname, 'dist')
   }
-}
+})


### PR DESCRIPTION
## Summary

Resolves #50 

Uses https://webpack.js.org/api/cli/#environment-options to set the environment variables in a cross platform way, without depending on process environment variables.