### PR TITLE
fix: do not use body tags in template

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one-express",
-  "version": "15.0.0",
+  "version": "15.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one-express",
-  "version": "15.0.0",
+  "version": "15.0.1",
   "description": "Generator to build Tram-One applications quickly",
   "bin": "./generator.js",
   "files": [

--- a/template/src/index.js
+++ b/template/src/index.js
@@ -10,9 +10,7 @@ const home = () => {
   return html`
     <div>
       <ColorHeader />
-      <body>
-        Thank you for using Tram-One!
-      </body>
+      Thank you for using Tram-One!
     </div>
   `
 }


### PR DESCRIPTION
## Summary

This was an oversight from previous template PR. We should never have a duplicate body tag in the page.