### PR TITLE
include babel-polyfill in app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one-express",
-  "version": "15.0.2",
+  "version": "15.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one-express",
-  "version": "15.0.2",
+  "version": "15.1.0",
   "description": "Generator to build Tram-One applications quickly",
   "bin": "./generator.js",
   "files": [

--- a/template/package.json
+++ b/template/package.json
@@ -2,14 +2,15 @@
   "name": "%TITLE%",
   "version": "1.0.0",
   "scripts": {
-    "start": "parcel index.html --open",
-    "build": "parcel build index.html",
+    "start": "parcel src/index.html --open",
+    "build": "parcel build src/index.html",
     "test": "jest --watch"
   },
   "dependencies": {
     "@babel/core": "7.2.0",
     "@babel/preset-env": "^7.4.5",
     "babel-jest": "^24.8.0",
+    "babel-polyfill": "6.26.0",
     "jest": "^24.8.0",
     "jest-transform-stub": "^2.0.0",
     "parcel-bundler": "^1.6.1",

--- a/template/package.json
+++ b/template/package.json
@@ -14,7 +14,7 @@
     "jest-transform-stub": "^2.0.0",
     "parcel-bundler": "^1.6.1",
     "sass": "^1.20.1",
-    "tram-one": "^8.1.0"
+    "tram-one": "^8.1.1"
   },
   "keywords": [
     "tram-one"

--- a/template/src/components/ColorHeader/ColorHeader.js
+++ b/template/src/components/ColorHeader/ColorHeader.js
@@ -12,7 +12,7 @@ export default () => {
 
   return html`
     <h1
-      classname="color-header"
+      class="color-header"
       style="color:${colors[colorIndex]}"
       onclick=${updateOnTitleClick}
     >

--- a/template/src/index.html
+++ b/template/src/index.html
@@ -7,7 +7,7 @@
   <body>
     <div id="app"></div>
 
-    <script src="src/index.js">
+    <script src="./index.js">
     </script>
   </body>
 </html>

--- a/template/src/index.js
+++ b/template/src/index.js
@@ -1,3 +1,4 @@
+import "babel-polyfill";
 import { registerHtml, start } from "tram-one"
 import ColorHeader from "./components/ColorHeader"
 import "./styles.css"


### PR DESCRIPTION
## Summary

In order to include async await calls, we need to include this babel-polyfill, see https://parceljs.org/code_splitting.html