### PR TITLE
Add tram-blueprints dependency

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "start": "parcel src/index.html --open",
     "build": "parcel build src/index.html",
-    "test": "jest --watch"
+    "test": "jest src --watch"
   },
   "dependencies": {
     "@babel/core": "7.2.0",
@@ -15,6 +15,7 @@
     "jest-transform-stub": "^2.0.0",
     "parcel-bundler": "^1.6.1",
     "sass": "^1.20.1",
+    "tram-blueprints": "^1.0.0",
     "tram-one": "^8.1.1"
   },
   "keywords": [


### PR DESCRIPTION
## Summary

This PR is to include the https://github.com/Tram-One/tram-blueprints project, which should make scaffolding components quicker! Check the readme there for how exactly to use it.