### PR TITLE
Add xo to generated files

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -16,7 +16,8 @@
     "parcel-bundler": "^1.6.1",
     "sass": "^1.20.1",
     "tram-blueprints": "^1.0.0",
-    "tram-one": "^8.1.1"
+    "tram-one": "^8.1.1",
+    "xo": "^0.23.0"
   },
   "keywords": [
     "tram-one"
@@ -34,5 +35,10 @@
   },
   "devDependencies": {
     "parcel-plugin-nuke-dist": "^1.0.0"
+  },
+  "xo": {
+    "extends": [
+      "tram-one"
+    ]
   }
 }

--- a/template/package.json
+++ b/template/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "start": "parcel src/index.html --open",
     "build": "parcel build src/index.html",
-    "test": "jest src --watch"
+    "test": "jest src --watch",
+    "lint": "xo"
   },
   "dependencies": {
     "@babel/core": "7.2.0",

--- a/template/package.json
+++ b/template/package.json
@@ -34,6 +34,7 @@
     }
   },
   "devDependencies": {
+    "eslint-config-tram-one": "^3.0.0",
     "parcel-plugin-nuke-dist": "^1.0.0"
   },
   "xo": {


### PR DESCRIPTION
Added the xo package and it's configuration to the template so that generated projects have xo linter in them by default.
Signed-off-by: Abhishek Ranjan <abhishekr700@gmail.com>