### PR TITLE
Linting for Project and Template

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -54,8 +54,9 @@ console.log('Initializing a git repository')
 console.log('Making the initial commit')
 const simplegit = git(projectPath)
 simplegit.init().add('.').commit('Initial commit from Tram-One Express', err => {
-	if (err) console.log('Failed to create commit')
-	else {
+	if (err) {
+		console.log('Failed to create commit')
+	} else {
 		console.log('Successfully created commit')
 	}
 })

--- a/generator.js
+++ b/generator.js
@@ -8,38 +8,38 @@ const git = require('simple-git')
 const appTitle = process.argv[2] || 'tram-one-app'
 
 const processFile = (file, currentPath) => {
-  const filePath = path.join(currentPath, file)
-  const newFilePath = filePath
-    .replace(path.join(__dirname, 'template'), path.join(process.cwd(), appTitle))
+	const filePath = path.join(currentPath, file)
+	const newFilePath = filePath
+		.replace(path.join(__dirname, 'template'), path.join(process.cwd(), appTitle))
 
-  // copy a directory
-  if (fs.existsSync(filePath) && fs.statSync(filePath).isDirectory()) {
-    // make the directory
-    if (fs.existsSync(newFilePath)) {
-      console.warn(`Folder ${newFilePath} already exists`)
-    } else {
-      fs.mkdirSync(newFilePath)
-    }
+	// copy a directory
+	if (fs.existsSync(filePath) && fs.statSync(filePath).isDirectory()) {
+		// make the directory
+		if (fs.existsSync(newFilePath)) {
+			console.warn(`Folder ${newFilePath} already exists`)
+		} else {
+			fs.mkdirSync(newFilePath)
+		}
 
-    // process all the files in the directory
-    const files = fs.readdirSync(filePath)
-    files.forEach(file => processFile(file, filePath))
-    return
-  }
+		// process all the files in the directory
+		const files = fs.readdirSync(filePath)
+		files.forEach(file => processFile(file, filePath))
+		return
+	}
 
-  // copy a file
-  if (fs.existsSync(newFilePath)) {
-    console.warn(`File ${newFilePath} already exists`)
-  } else {
-    const newFile = fs.readFileSync(filePath)
-    if (filePath.match(/.*\.(png|ttf)/)) {
-      fs.appendFileSync(newFilePath, newFile)
-    } else {
-      // if it's not a binary file, treat it as a template
-      const templateFile = newFile.toString().replace(/%TITLE%/g, appTitle)
-      fs.appendFileSync(newFilePath, templateFile)
-    }
-  }
+	// copy a file
+	if (fs.existsSync(newFilePath)) {
+		console.warn(`File ${newFilePath} already exists`)
+	} else {
+		const newFile = fs.readFileSync(filePath)
+		if (filePath.match(/.*\.(png|ttf)/)) {
+			fs.appendFileSync(newFilePath, newFile)
+		} else {
+			// if it's not a binary file, treat it as a template
+			const templateFile = newFile.toString().replace(/%TITLE%/g, appTitle)
+			fs.appendFileSync(newFilePath, templateFile)
+		}
+	}
 }
 
 const filePath = path.join(__dirname, 'template')
@@ -53,11 +53,11 @@ execSync('npm install', {cwd: projectPath, stdio: 'inherit'})
 console.log('Initializing a git repository')
 console.log('Making the initial commit')
 const simplegit = git(projectPath)
-simplegit.init().add('.').commit('Initial commit from Tram-One Express', (err) => {
-  if (err) console.log('Failed to create commit')
-  else {
-    console.log('Successfully created commit')
-  }
+simplegit.init().add('.').commit('Initial commit from Tram-One Express', err => {
+	if (err) console.log('Failed to create commit')
+	else {
+		console.log('Successfully created commit')
+	}
 })
 console.log('')
 console.log('Finished!')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1690,9 +1690,9 @@
       }
     },
     "eslint-config-tram-one": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-tram-one/-/eslint-config-tram-one-1.1.0.tgz",
-      "integrity": "sha512-Y1UIPUw66LLscOOjsq4qJg/8cnZhBeVjFbxe74KtruYy0PxUuRQx/2KERfs+v0f4mSXiEPf8WCQcDREUOCV90A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-tram-one/-/eslint-config-tram-one-3.0.0.tgz",
+      "integrity": "sha512-MHBkdLBkPos8pJmGhnFAByHVOZmPcfw+HvQI1zYEbcwkT8YiVwCUuhCbTM0XJJkmZ4+AtPr+uiLMGzG6ZfKxHw==",
       "dev": true
     },
     "eslint-config-xo": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "fs-extra": "^4.0.2"
   },
   "devDependencies": {
-    "eslint-config-tram-one": "^1.1.0",
+    "eslint-config-tram-one": "^3.0.0",
     "jasmine": "^3.1.0",
     "nightmare": "^3.0.1",
     "node-fetch": "^2.1.2",

--- a/template/package.json
+++ b/template/package.json
@@ -12,6 +12,7 @@
     "jest": "^24.8.0",
     "jest-transform-stub": "^2.0.0",
     "parcel-bundler": "^1.6.1",
+    "regenerator-runtime": "^0.13.3",
     "sass": "^1.20.1",
     "tram-blueprints": "^1.0.0",
     "tram-one": "^8.1.1",

--- a/template/src/components/ColorHeader/ColorHeader.js
+++ b/template/src/components/ColorHeader/ColorHeader.js
@@ -1,16 +1,17 @@
-import { registerHtml, useState } from "tram-one"
-import "./ColorHeader.scss"
+import {registerHtml, useState} from 'tram-one'
+import './ColorHeader.scss'
+
 const html = registerHtml()
 
 export default () => {
-  const colors = ["#e6ef9f", "#a09fef", "#9fefa1", "#ef9f9f"]
-  const [colorIndex, setColorIndex] = useState(0)
+	const colors = ['#e6ef9f', '#a09fef', '#9fefa1', '#ef9f9f']
+	const [colorIndex, setColorIndex] = useState(0)
 
-  const updateOnTitleClick = event => {
-    setColorIndex((colorIndex + 1) % colors.length)
-  }
+	const updateOnTitleClick = () => {
+		setColorIndex((colorIndex + 1) % colors.length)
+	}
 
-  return html`
+	return html`
     <h1
       class="color-header"
       style="color:${colors[colorIndex]}"

--- a/template/src/components/ColorHeader/ColorHeader.test.js
+++ b/template/src/components/ColorHeader/ColorHeader.test.js
@@ -1,23 +1,23 @@
-import ColorHeader from './ColorHeader';
+import ColorHeader from './ColorHeader'
 
 const mockColor = 1
 const mockUpdateColor = jest.fn()
 
 // mock and spy on tram-one hooks
 jest.mock('tram-one', () => ({
-  ...(jest.requireActual('tram-one')),
-  useState: () => [mockColor, mockUpdateColor]
-}));
+	...(jest.requireActual('tram-one')),
+	useState: () => [mockColor, mockUpdateColor]
+}))
 
 describe('ColorHeader', () => {
-  it('should match snapshot', () => {
-    const header = ColorHeader();
-    expect(header.outerHTML).toMatchSnapshot();
-  });
+	it('should match snapshot', () => {
+		const header = ColorHeader()
+		expect(header.outerHTML).toMatchSnapshot()
+	})
 
-  it('should call mockSetColor on click', () => {
-    const header = ColorHeader();
-    header.click()
-    expect(mockUpdateColor).toHaveBeenCalled()
-  });
-});
+	it('should call mockSetColor on click', () => {
+		const header = ColorHeader()
+		header.click()
+		expect(mockUpdateColor).toHaveBeenCalled()
+	})
+})

--- a/template/src/components/ColorHeader/index.js
+++ b/template/src/components/ColorHeader/index.js
@@ -1,1 +1,1 @@
-export { default } from './ColorHeader';
+export {default} from './ColorHeader'

--- a/template/src/index.html
+++ b/template/src/index.html
@@ -1,13 +1,16 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <title>%TITLE%</title>
-    <meta charset="UTF-8" />
-  </head>
-  <body>
-    <div id="app"></div>
 
-    <script src="./index.js">
-    </script>
-  </body>
+<head>
+  <title>%TITLE%</title>
+  <meta charset="UTF-8" />
+</head>
+
+<body>
+  <div id="app"></div>
+
+  <script src="./index.js">
+  </script>
+</body>
+
 </html>

--- a/template/src/index.js
+++ b/template/src/index.js
@@ -1,15 +1,15 @@
-import "core-js/stable";
-import "regenerator-runtime/runtime";
-import { registerHtml, start } from "tram-one"
-import ColorHeader from "./components/ColorHeader"
-import "./styles.css"
+import 'core-js/stable'
+import 'regenerator-runtime/runtime'
+import {registerHtml, start} from 'tram-one'
+import ColorHeader from './components/ColorHeader'
+import './styles.css'
 
 const html = registerHtml({
-  ColorHeader
+	ColorHeader
 })
 
 const home = () => {
-  return html`
+	return html`
     <div>
       <ColorHeader />
       Thank you for using Tram-One!
@@ -17,4 +17,4 @@ const home = () => {
   `
 }
 
-start("#app", home)
+start('#app', home)


### PR DESCRIPTION
## Summary

Fixes #74 
This PR updates the template and project files to follow the linting based on the tram-one eslint config. It is mostly whitespace changes, and ensures that the `npm run lint` command will not fail on generating a project.