### PR TITLE
Add check for npmignore and change to gitignore

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -32,8 +32,11 @@ const processFile = (file, currentPath) => {
 		console.warn(`File ${newFilePath} already exists`)
 	} else {
 		const newFile = fs.readFileSync(filePath)
-		if (filePath.match(/.*\.(png|ttf)/)) {
+		if ((filePath.match(/.*\.(png|ttf)/)) || filePath.match(/.gitignore/)) {
 			fs.appendFileSync(newFilePath, newFile)
+		} else if(filePath.match(/.npmignore/)) {
+			const gitignore = newFile.toString().replace('.npmignore', '.gitignore')
+			fs.appendFileSync(newFilePath, gitignore)
 		} else {
 			// if it's not a binary file, treat it as a template
 			const templateFile = newFile.toString().replace(/%TITLE%/g, appTitle)

--- a/generator.js
+++ b/generator.js
@@ -32,9 +32,11 @@ const processFile = (file, currentPath) => {
 		console.warn(`File ${newFilePath} already exists`)
 	} else {
 		const newFile = fs.readFileSync(filePath)
-		if ((filePath.match(/.*\.(png|ttf)/)) || filePath.match(/.gitignore/)) {
+		if (filePath.match(/.*\.(png|ttf)/)) {
 			fs.appendFileSync(newFilePath, newFile)
 		} else if (filePath.match(/.npmignore/)) {
+			// the gitignore file becomes an npmignore and we need to
+			// change it back when laying down the project
 			const gitignore = newFile.toString().replace('.npmignore', '.gitignore')
 			fs.appendFileSync(newFilePath, gitignore)
 		} else {

--- a/generator.js
+++ b/generator.js
@@ -34,7 +34,7 @@ const processFile = (file, currentPath) => {
 		const newFile = fs.readFileSync(filePath)
 		if ((filePath.match(/.*\.(png|ttf)/)) || filePath.match(/.gitignore/)) {
 			fs.appendFileSync(newFilePath, newFile)
-		} else if(filePath.match(/.npmignore/)) {
+		} else if (filePath.match(/.npmignore/)) {
 			const gitignore = newFile.toString().replace('.npmignore', '.gitignore')
 			fs.appendFileSync(newFilePath, gitignore)
 		} else {

--- a/generator.js
+++ b/generator.js
@@ -37,8 +37,8 @@ const processFile = (file, currentPath) => {
 		} else if (filePath.match(/.npmignore/)) {
 			// the gitignore file becomes an npmignore and we need to
 			// change it back when laying down the project
-			const gitignore = newFile.toString().replace('.npmignore', '.gitignore')
-			fs.appendFileSync(newFilePath, gitignore)
+			const gitignorePath = newFilePath.toString().replace('.npmignore', '.gitignore')
+			fs.appendFileSync(gitignorePath, newFile)
 		} else {
 			// if it's not a binary file, treat it as a template
 			const templateFile = newFile.toString().replace(/%TITLE%/g, appTitle)


### PR DESCRIPTION
Solves #64 
**Summary:** 
Originally, when the generator is run, the .npmignore file overwrote the .gitignore file. Since there does not need to be an npmignore file/ webapps probably shouldn't be published to npm, I did a check for the npmignore file and renamed it to .gitignore